### PR TITLE
Fixed Nil Pointer Exception 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Test
+
 # NIST GoBGPsec 
 GoBGPsec uses NIST SRxCrypto library to facilitate crypto calculations
 which is able to sign and verify X.509 objects for BGPSec path validation. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+# Test
 # NIST GoBGPsec 
 GoBGPsec uses NIST SRxCrypto library to facilitate crypto calculations
 which is able to sign and verify X.509 objects for BGPSec path validation. 

--- a/internal/pkg/apiutil/capability.go
+++ b/internal/pkg/apiutil/capability.go
@@ -117,6 +117,10 @@ func NewUnknownCapability(a *bgp.CapUnknown) *api.UnknownCapability {
 	}
 }
 
+func NewBGPCapability(a *bgp.CapBGPSecCapability) *api.BgpsecAttribute {
+	return &api.BgpsecAttribute{}
+}
+
 func MarshalCapability(value bgp.ParameterCapabilityInterface) (*any.Any, error) {
 	var m proto.Message
 	switch n := value.(type) {
@@ -142,6 +146,8 @@ func MarshalCapability(value bgp.ParameterCapabilityInterface) (*any.Any, error)
 		m = NewRouteRefreshCiscoCapability(n)
 	case *bgp.CapUnknown:
 		m = NewUnknownCapability(n)
+	case *bgp.CapBGPSecCapability:
+		m = NewBGPCapability(n)
 	default:
 		return nil, fmt.Errorf("invalid capability type to marshal: %+v", value)
 	}


### PR DESCRIPTION
While using gobgpsrx I ran into a nil pointer execption. This is triggered when, after starting gobgpd, gobgp is called with the neigh option. The added lines of code prevent the nil pointer. The problem was that no data was passed from the BGPSec extension when the neigh function was called. Instead a nil pointer was passed which eventually caused the error and crashed gobgpd. I have tested both the bug and the fix on three systems, each with the same result. 

![Screenshot](https://user-images.githubusercontent.com/91960250/231411072-7fffd7b4-ee43-42e0-bcf8-d0d7c61d3961.png)
